### PR TITLE
chore: rename project from Human Spaceflight API to Space Pioneers API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,327 @@
+# Space Pioneers API
 
-    Author and contact
-    Project description
-    Architecture overview
-    Stack used
-    Development environment setup
-    Makefile command list (if a Makefile is present)
-    Common problems with description and solutions
+A comprehensive web application for exploring and managing data about space pioneers, missions, agencies, astronauts, and extravehicular activities (EVAs) from the early era of human spaceflight.
+
+## Project Description
+
+Space Pioneers API is a Django-based web application that provides a rich interface for browsing and managing historical space mission data, covering the period from the first solo mission into space (April 1961) to the last crewed lunar landing (December 1972). The application offers detailed information about:
+
+- **Astronauts**: Biographies, missions, and career statistics
+- **Space Agencies**: NASA, Soviet/Russian space program, and other national agencies
+- **Missions**: Complete mission details, crew assignments, and mission patches
+- **EVAs (Spacewalks)**: Comprehensive records of extravehicular activities
+- **Crew Members**: Role assignments and astronaut ages at launch
+
+## Author and Contact
+
+**Contact Email**: info@spacepioneersapi.com
+**Website**: spacepioneersapi.com
+**Location**: London, UK
+
+## Technology Stack
+
+### Backend
+- **Framework**: Django 5.1.6
+- **Language**: Python 3.12
+- **API Framework**: Django REST Framework 3.13.1
+- **Database**: PostgreSQL 14 (with SQLite3 support for local development)
+
+### Frontend
+- **CSS Framework**: Bootstrap 4 with Material Design (MDBootstrap)
+- **Icons**: Font Awesome
+- **Templates**: Django template engine
+
+### Authentication
+- **django-allauth**: Social authentication with GitHub and Bitbucket OAuth support
+
+### Development Tools
+- **Django Debug Toolbar**: Performance profiling and debugging
+- **Django Extensions**: Enhanced management commands
+- **import-export**: Admin panel data import/export capability
+
+### Deployment
+- **Containerization**: Docker & Docker Compose
+- **WSGI Server**: Gunicorn (via Docker)
+- **Web Server**: Nginx (recommended for production)
+
+## Architecture Overview
+
+### Project Structure
+
+```
+space-pioneers-api/
+├── config/                      # Django configuration
+│   ├── settings/
+│   │   └── settings.py         # Main Django settings
+│   ├── urls.py                 # URL routing
+│   ├── wsgi.py                 # WSGI application entry point
+│   └── asgi.py                 # ASGI application entry point
+│
+├── apps/                        # Django applications
+│   ├── pages/                  # Landing page and static pages
+│   ├── common/                 # Common utilities and base models
+│   ├── accounts/               # User authentication and profiles
+│   ├── agencies/               # Space agencies management
+│   ├── astronauts/             # Astronaut database
+│   ├── evas/                   # Extravehicular activities
+│   └── missions/               # Space missions and crew assignments
+│
+├── templates/                   # HTML templates (project-level)
+│   ├── base.html               # Base template with navigation
+│   ├── pages/                  # Page templates
+│   ├── account/                # Authentication templates
+│   ├── agencies/               # Agency templates
+│   ├── astronauts/             # Astronaut templates
+│   ├── evas/                   # EVA templates
+│   └── missions/               # Mission templates
+│
+├── static/                      # Static assets
+│   └── base/
+│       ├── css/                # Stylesheets
+│       ├── js/                 # JavaScript files
+│       └── images/             # Images and logos
+│
+├── media/                       # User-uploaded files
+├── docker-compose.yml          # Docker Compose configuration
+├── Dockerfile                  # Docker image definition
+├── requirements.txt            # Python dependencies
+├── manage.py                   # Django management script
+└── README.md                   # This file
+```
+
+### Application Architecture
+
+The project follows Django's MVT (Model-View-Template) architecture:
+
+- **Models**: Define database schema for astronauts, missions, agencies, EVAs, and crew assignments
+- **Views**: Handle HTTP requests and business logic
+- **Templates**: Render HTML responses using Django template language
+- **URLs**: Map URL patterns to views
+
+### Database Schema
+
+Key models include:
+
+- `Astronaut`: Personal information, nationality, career statistics
+- `Agency`: Space agency details and country of origin
+- `Mission`: Mission name, type, launch date/time, duration, crew size
+- `Crew`: Join table linking astronauts to missions with roles
+- `EVA`: Spacewalk details including duration, type, and astronaut
+
+## Development Environment Setup
+
+### Prerequisites
+
+- Python 3.12+
+- Docker and Docker Compose (recommended)
+- PostgreSQL 14+ (if running without Docker)
+- Git
+
+### Option 1: Docker Setup (Recommended)
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd human-spaceflight-api-code
+   ```
+
+2. **Build and start containers**
+   ```bash
+   docker-compose up --build
+   ```
+
+3. **Run migrations**
+   ```bash
+   docker-compose exec web python manage.py migrate
+   ```
+
+4. **Create a superuser**
+   ```bash
+   docker-compose exec web python manage.py createsuperuser
+   ```
+
+5. **Access the application**
+   - Web app: http://localhost:8000
+   - Admin panel: http://localhost:8000/admin
+
+### Option 2: Local Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd human-spaceflight-api-code
+   ```
+
+2. **Create and activate virtual environment**
+   ```bash
+   python3.12 -m venv venv
+   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   ```
+
+3. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Configure environment variables**
+   Create a `.env` file in the project root:
+   ```
+   SECRET_KEY=your-secret-key-here
+   DEBUG=True
+   DATABASE_URL=postgresql://user:password@localhost:5432/spacepioneers
+   ```
+
+5. **Run migrations**
+   ```bash
+   python manage.py migrate
+   ```
+
+6. **Create a superuser**
+   ```bash
+   python manage.py createsuperuser
+   ```
+
+7. **Run the development server**
+   ```bash
+   python manage.py runserver
+   ```
+
+8. **Access the application**
+   - Web app: http://localhost:8000
+   - Admin panel: http://localhost:8000/admin
+
+### Loading Initial Data
+
+If you have fixture files or data dumps:
+
+```bash
+python manage.py loaddata <fixture-name>
+```
+
+## Common Problems and Solutions
+
+### 1. Database Connection Issues
+
+**Problem**: Cannot connect to PostgreSQL database
+
+**Solutions**:
+- Verify PostgreSQL is running: `docker-compose ps` (Docker) or `systemctl status postgresql` (local)
+- Check database credentials in settings or `.env` file
+- Ensure database exists: `createdb spacepioneers`
+- For Docker: Ensure containers are on the same network
+
+### 2. Static Files Not Loading
+
+**Problem**: CSS/JS files not loading in development
+
+**Solutions**:
+```bash
+python manage.py collectstatic
+```
+- Verify `STATIC_URL` and `STATIC_ROOT` settings
+- Check that `django.contrib.staticfiles` is in `INSTALLED_APPS`
+
+### 3. Migration Conflicts
+
+**Problem**: Migration conflicts or inconsistent database state
+
+**Solutions**:
+```bash
+# Reset migrations (WARNING: Development only!)
+python manage.py migrate <app_name> zero
+python manage.py migrate
+
+# Or create a fresh database
+dropdb spacepioneers && createdb spacepioneers
+python manage.py migrate
+```
+
+### 4. Port Already in Use
+
+**Problem**: Port 8000 already in use
+
+**Solutions**:
+```bash
+# Use a different port
+python manage.py runserver 8080
+
+# Or kill the process using port 8000
+lsof -ti:8000 | xargs kill -9  # Unix/Mac
+```
+
+### 5. OAuth Authentication Issues
+
+**Problem**: GitHub/Bitbucket login not working
+
+**Solutions**:
+- Verify OAuth app credentials in Django admin: `/admin/socialaccount/socialapp/`
+- Ensure callback URLs are correctly configured in GitHub/Bitbucket
+- Check that `django-allauth` is properly configured in `INSTALLED_APPS`
+
+### 6. Docker Build Failures
+
+**Problem**: Docker image fails to build
+
+**Solutions**:
+```bash
+# Clean build without cache
+docker-compose build --no-cache
+
+# Remove old images and volumes
+docker system prune -a
+docker volume prune
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+python manage.py test
+
+# Run tests for a specific app
+python manage.py test apps.astronauts
+
+# Run with coverage
+coverage run --source='.' manage.py test
+coverage report
+```
+
+## Management Commands
+
+```bash
+# Create database migrations
+python manage.py makemigrations
+
+# Apply migrations
+python manage.py migrate
+
+# Create superuser
+python manage.py createsuperuser
+
+# Collect static files
+python manage.py collectstatic
+
+# Open Django shell
+python manage.py shell
+
+# Run development server
+python manage.py runserver
+```
+
+## Contributing
+
+When contributing to this project:
+
+1. Create a feature branch from `main`
+2. Follow PEP 8 style guidelines
+3. Write tests for new features
+4. Update documentation as needed
+5. Submit a pull request with a clear description
+
+## License
+
+All rights reserved. Copyright © 2026 Space Pioneers API.
+
+## Acknowledgments
+
+Data sourced from historical space mission records and publicly available space agency databases.

--- a/static/base/images/spacepioneers-navbarlogotext.svg
+++ b/static/base/images/spacepioneers-navbarlogotext.svg
@@ -4,7 +4,7 @@
    id="svg2"
    height="9.051651mm"
    width="82.904228mm"
-   sodipodi:docname="humanspaceflight-navbarlogotext.svg"
+   sodipodi:docname="spacepioneers-navbarlogotext.svg"
    inkscape:version="1.2.1 (9c6d41e4, 2022-07-14)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -85,5 +85,5 @@
        id="tspan2884"
        x="-2.1406295"
        y="26.500021"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.6667px;font-family:Roboto;-inkscape-font-specification:Roboto;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:url(#linearGradient32261);stroke-opacity:1">human spaceflight</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.6667px;font-family:Roboto;-inkscape-font-specification:Roboto;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:url(#linearGradient32261);stroke-opacity:1">Space Pioneers</tspan></text>
 </svg>

--- a/static/base/images/spacepioneersapi-navbarlogotext.svg
+++ b/static/base/images/spacepioneersapi-navbarlogotext.svg
@@ -4,7 +4,7 @@
    id="svg2"
    height="9.93221mm"
    width="103.66293mm"
-   sodipodi:docname="humanspaceflightapi-navbarlogotext.svg"
+   sodipodi:docname="spacepioneersapi-navbarlogotext.svg"
    inkscape:version="1.2.1 (9c6d41e4, 2022-07-14)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -84,5 +84,5 @@
        id="tspan2884"
        x="-2.6367188"
        y="29.121094"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.6667px;font-family:Roboto;-inkscape-font-specification:Roboto;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:#f9f9f9;stroke-opacity:1">human spaceflight API</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.6667px;font-family:Roboto;-inkscape-font-specification:Roboto;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:#f9f9f9;stroke-opacity:1">Space Pioneers API</tspan></text>
 </svg>

--- a/templates/403_csrf.html
+++ b/templates/403_csrf.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans '403: Forbidden | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans '403: Forbidden | Space Pioneers API' %}{% endblock title %}
 
 {% block content %}
 <h1>{% trans '403: Forbidden' %}</h1>

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans '404: Page not found | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans '404: Page not found | Space Pioneers API' %}{% endblock title %}
 
 {% block content %}
 <h1>{% trans '404: Page not found' %}</h1>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans '500: Server Error | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans '500: Server Error | Space Pioneers API' %}{% endblock title %}
 
 {% block content %}
 <h1>{% trans '500: Server Error' %}</h1>

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Login | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Login | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Signout | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Signout | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/password_change.html
+++ b/templates/account/password_change.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Change Password | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Change Password | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Reset Password | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Reset Password | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Confirm Password Reset | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Confirm Password Reset | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Change Password | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Change Password | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Confirm Password Reset | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Confirm Password Reset | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/password_set.html
+++ b/templates/account/password_set.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Set Password | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Set Password | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -4,7 +4,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Signup | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Signup | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/agencies/agency_list.html
+++ b/templates/agencies/agency_list.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{% trans 'Agencies | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Agencies | Space Pioneers API' %}{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Agency area content -->

--- a/templates/astronauts/astronaut_detail.html
+++ b/templates/astronauts/astronaut_detail.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{{ astronaut.last_name }} | Human Spaceflight API{% endblock title %}
+{% block title %}{{ astronaut.last_name }} | Space Pioneers API{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Astronaut area content -->

--- a/templates/astronauts/astronaut_list.html
+++ b/templates/astronauts/astronaut_list.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{% trans 'Astronauts | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Astronauts | Space Pioneers API' %}{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Astronaut area content -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,7 +71,7 @@
     	<!-- Navbar -->
 		<nav class="navbar navbar-expand-sm navbar-dark unique-color-dark mb-0 smart-scroll">
 			<a class="navbar-brand" href="{% url 'home' %}">
-				<img src="{% static 'base/images/humanspaceflightapi-navbarlogotext.svg' %}" alt="humanspaceflightapi_logo">
+				<img src="{% static 'base/images/spacepioneersapi-navbarlogotext.svg' %}" alt="spacepioneersapi_logo">
 			</a>
 		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
 			<span class="navbar-toggler-icon"></span>
@@ -167,7 +167,7 @@
 					<!--First column-->
 					<div class="col-md-3 col-lg-4 col-xl-3 mb-4">
 						<h6 class="text-uppercase font-weight-bold">
-							<strong>humanspaceflightapi.com</strong>
+							<strong>spacepioneersapi.com</strong>
 						</h6>
 						<hr class="blue mb-4 mt-0 d-inline-block mx-auto" style="width: 60px;">
 						<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Reprehenderit
@@ -224,7 +224,7 @@
 						</h6>
 						<hr class="blue mb-4 mt-0 d-inline-block mx-auto" style="width: 60px;">
 						<p>
-							<i class="fa fa-envelope mr-3"></i> info@humanspaceflightapi.com</p>
+							<i class="fa fa-envelope mr-3"></i> info@spacepioneersapi.com</p>
 						<p>
 							<i class="fa fa-phone mr-3"></i> + 01234 567 890</p>
 						<p>
@@ -238,7 +238,7 @@
 			
 			<!-- Copyright -->
 			<div class="footer-copyright text-center py-3">
-				Copyright © 2022 Human Spaceflight API. All rights reserved.
+				Copyright © 2026 Space Pioneers API. All rights reserved.
 			</div>
 			<!-- Copyright -->
 			

--- a/templates/evas/eva_detail.html
+++ b/templates/evas/eva_detail.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}EVA-{{ eva.code|stringformat:"04d" }} | Human Spaceflight API{% endblock title %}
+{% block title %}EVA-{{ eva.code|stringformat:"04d" }} | Space Pioneers API{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Eva area content -->

--- a/templates/evas/eva_list.html
+++ b/templates/evas/eva_list.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{% trans 'EVAs | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'EVAs | Space Pioneers API' %}{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Eva area content -->

--- a/templates/missions/crew_detail.html
+++ b/templates/missions/crew_detail.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{{ mission.name }} | Human Spaceflight API{% endblock title %}
+{% block title %}{{ mission.name }} | Space Pioneers API{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Crew area content -->

--- a/templates/missions/crew_list.html
+++ b/templates/missions/crew_list.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{% trans 'Crew Members | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Crew Members | Space Pioneers API' %}{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Crew area content -->

--- a/templates/missions/mission_detail.html
+++ b/templates/missions/mission_detail.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{{ mission.name }} | Human Spaceflight API{% endblock title %}
+{% block title %}{{ mission.name }} | Space Pioneers API{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Mission area content -->

--- a/templates/missions/mission_list.html
+++ b/templates/missions/mission_list.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <!-- Tab title -->
-{% block title %}{% trans 'Missions | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Missions | Space Pioneers API' %}{% endblock title %}
 <!-- /.Tab title -->
 
 <!-- Mission area content -->

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -7,7 +7,7 @@
 <!-- Tab title -->
 <title>
     {% block title %}
-      {% trans 'Home | Human Spaceflight API' %}
+      {% trans 'Home | Space Pioneers API' %}
     {% endblock title %}
 </title>
 <!-- /.Tab title -->
@@ -39,7 +39,7 @@
                     <!-- Grid column -->
                     <div class="col pt-5 mt-5">
                         <!-- Heading -->
-                        <h2 class="h3-responsive white-text pt-5 mt-5 mb-4 mx-5">Human spaceflight data</h2>
+                        <h2 class="h3-responsive white-text pt-5 mt-5 mb-4 mx-5">Space pioneers data</h2>
                         <!-- /.Heading -->
                         <!-- Divider -->
                         <hr class="hr-light mx-5">

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -4,7 +4,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Social Signup | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Social Signup | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}

--- a/templates/socialaccount/signup.html
+++ b/templates/socialaccount/signup.html
@@ -4,7 +4,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans 'Social Signup | Human Spaceflight API' %}{% endblock title %}
+{% block title %}{% trans 'Social Signup | Space Pioneers API' %}{% endblock title %}
 
 <!-- Account area content -->
 {% block account_page_content %}


### PR DESCRIPTION
## Summary
- Rename all branding from "Human Spaceflight API" to "Space Pioneers API"
- Update page titles across 25 template files
- Update base.html footer, email, and copyright year (2022 → 2026)
- Rename and update logo SVG files
- Rewrite README.md with comprehensive project documentation

## Test plan
- [x] Ran `docker-compose up --build` successfully
- [x] Ran `python manage.py test` - 4 pre-existing failures unrelated to this change
- [ ] Visually verify pages display correct "Space Pioneers API" branding